### PR TITLE
user - authentication 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/user/authentication/controller/AuthenticationController.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/controller/AuthenticationController.java
@@ -1,13 +1,9 @@
 package daehee.challengehub.user.authentication.controller;
 
-import daehee.challengehub.user.authentication.model.PasswordChangeDto;
-import daehee.challengehub.user.authentication.model.UserLoginDto;
-import daehee.challengehub.user.authentication.model.UserSignupDto;
+import daehee.challengehub.user.authentication.model.*;
 import daehee.challengehub.user.authentication.service.AuthenticationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -21,22 +17,23 @@ public class AuthenticationController {
     }
 
     @PostMapping("/users")
-    public Map<String, Object> signup(@RequestBody UserSignupDto userSignupDto) {
+    public SignupResponseDto signup(@RequestBody UserSignupDto userSignupDto) {
         return authenticationService.signup(userSignupDto);
     }
 
+
     @GetMapping("/users/verify/{token}")
-    public Map<String, String> verifyEmail(@PathVariable String token) {
+    public VerifyEmailResponseDto verifyEmail(@PathVariable String token) {
         return authenticationService.verifyEmail(token);
     }
 
     @PostMapping("/login")
-    public Map<String, String> login(@RequestBody UserLoginDto userLoginDto) {
+    public LoginResponseDto login(@RequestBody UserLoginDto userLoginDto) {
         return authenticationService.login(userLoginDto);
     }
 
     @PostMapping("/password/reset")
-    public Map<String, String> resetPassword(@RequestBody PasswordChangeDto passwordChangeDto) {
+    public ResetPasswordResponseDto resetPassword(@RequestBody PasswordChangeDto passwordChangeDto) {
         return authenticationService.resetPassword(passwordChangeDto);
     }
 }

--- a/api/src/main/java/daehee/challengehub/user/authentication/model/LoginResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/model/LoginResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.user.authentication.model;
+
+import lombok.Data;
+
+@Data
+public class LoginResponseDto {
+    private final String message;
+    private final String userEmail;
+}

--- a/api/src/main/java/daehee/challengehub/user/authentication/model/ResetPasswordResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/model/ResetPasswordResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.user.authentication.model;
+
+import lombok.Data;
+
+@Data
+public class ResetPasswordResponseDto {
+    private final String message;
+    private final String newPassword;
+}

--- a/api/src/main/java/daehee/challengehub/user/authentication/model/SignupResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/model/SignupResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.user.authentication.model;
+
+import lombok.Data;
+
+@Data
+public class SignupResponseDto {
+    private final String message;
+    private final UserSignupDto user;
+}

--- a/api/src/main/java/daehee/challengehub/user/authentication/model/VerifyEmailResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/model/VerifyEmailResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.user.authentication.model;
+
+import lombok.Data;
+
+@Data
+public class VerifyEmailResponseDto {
+    private final String message;
+    private final String token;
+}

--- a/api/src/main/java/daehee/challengehub/user/authentication/service/AuthenticationService.java
+++ b/api/src/main/java/daehee/challengehub/user/authentication/service/AuthenticationService.java
@@ -1,16 +1,11 @@
 package daehee.challengehub.user.authentication.service;
 
-import daehee.challengehub.user.authentication.model.PasswordChangeDto;
-import daehee.challengehub.user.authentication.model.UserLoginDto;
-import daehee.challengehub.user.authentication.model.UserSignupDto;
-import daehee.challengehub.user.authentication.repository.AuthenticationRepository;
 import daehee.challengehub.common.constants.ErrorCode;
 import daehee.challengehub.common.exception.CustomException;
+import daehee.challengehub.user.authentication.model.*;
+import daehee.challengehub.user.authentication.repository.AuthenticationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Service
 public class AuthenticationService {
@@ -22,49 +17,47 @@ public class AuthenticationService {
     }
 
     // 회원가입 로직
-    public Map<String, Object> signup(UserSignupDto userSignupDto) {
+    public SignupResponseDto signup(UserSignupDto userSignupDto) {
         // 레포지토리를 통해 사용자 정보 저장
         authenticationRepository.save(userSignupDto);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "회원가입 성공");
-        response.put("user", userSignupDto);
-        return response;
+        // SignupResponseDto 반환
+        return new SignupResponseDto("회원가입 성공", userSignupDto);
     }
 
+
     // 이메일 인증 로직
-    public Map<String, String> verifyEmail(String token) {
+    public VerifyEmailResponseDto verifyEmail(String token) {
         if (authenticationRepository.isEmailVerified(token)) {
-            return Map.of("message", "이메일 인증 성공", "token", token);
+            // VerifyEmailResponseDto 반환
+            return new VerifyEmailResponseDto("이메일 인증 성공", token);
         } else {
             throw new CustomException(ErrorCode.TOKEN_INVALID);
         }
     }
 
+
     // 로그인 로직
-    public Map<String, String> login(UserLoginDto userLoginDto) {
+    public LoginResponseDto login(UserLoginDto userLoginDto) {
         boolean isValidLogin = authenticationRepository.validateLogin(
                 userLoginDto.getEmail(), userLoginDto.getPassword());
 
         if (isValidLogin) {
-            Map<String, String> response = new HashMap<>();
-            response.put("message", "로그인 성공");
-            response.put("userEmail", userLoginDto.getEmail());
-            return response;
+            // LoginResponseDto 반환
+            return new LoginResponseDto("로그인 성공", userLoginDto.getEmail());
         } else {
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
     }
 
+
     // 비밀번호 재설정 로직
-    public Map<String, String> resetPassword(PasswordChangeDto passwordChangeDto) {
+    public ResetPasswordResponseDto resetPassword(PasswordChangeDto passwordChangeDto) {
         // 레포지토리를 통해 비밀번호 업데이트
         authenticationRepository.updatePassword(
                 passwordChangeDto.getCurrentPassword(), passwordChangeDto.getNewPassword());
 
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "비밀번호 재설정 성공");
-        response.put("newPassword", passwordChangeDto.getNewPassword());
-        return response;
+        // ResetPasswordResponseDto 반환
+        return new ResetPasswordResponseDto("비밀번호 재설정 성공", passwordChangeDto.getNewPassword());
     }
 }

--- a/api/src/test/java/user/service/AuthenticationServiceTest.java
+++ b/api/src/test/java/user/service/AuthenticationServiceTest.java
@@ -1,18 +1,14 @@
 package user.service;
 
-import daehee.challengehub.user.authentication.model.PasswordChangeDto;
-import daehee.challengehub.user.authentication.model.UserLoginDto;
-import daehee.challengehub.user.authentication.model.UserSignupDto;
+import daehee.challengehub.common.exception.CustomException;
+import daehee.challengehub.user.authentication.model.*;
 import daehee.challengehub.user.authentication.repository.AuthenticationRepository;
 import daehee.challengehub.user.authentication.service.AuthenticationService;
-import daehee.challengehub.common.exception.CustomException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,32 +34,42 @@ public class AuthenticationServiceTest {
                 .email("standard@example.com")
                 .password("password123")
                 .build();
+
         // When
-        Map<String, Object> response = authenticationService.signup(signupDto);
+        SignupResponseDto response = authenticationService.signup(signupDto);
+
         // Then
-        assertEquals("회원가입 성공", response.get("message"));
+        assertEquals("회원가입 성공", response.getMessage());
+        assertEquals(signupDto, response.getUser());
         verify(authenticationRepository).save(signupDto);
     }
+
 
     @Test
     public void testVerifyEmail_ValidToken() {
         // Given
         String validToken = "validToken123";
         when(authenticationRepository.isEmailVerified(validToken)).thenReturn(true);
+
         // When
-        Map<String, String> response = authenticationService.verifyEmail(validToken);
+        VerifyEmailResponseDto response = authenticationService.verifyEmail(validToken);
+
         // Then
-        assertEquals("이메일 인증 성공", response.get("message"));
+        assertEquals("이메일 인증 성공", response.getMessage());
+        assertEquals(validToken, response.getToken());
     }
+
 
     @Test
     public void testVerifyEmail_InvalidToken() {
         // Given
         String invalidToken = "invalidToken123";
         when(authenticationRepository.isEmailVerified(invalidToken)).thenReturn(false);
+
         // When & Then
         assertThrows(CustomException.class, () -> authenticationService.verifyEmail(invalidToken));
     }
+
 
     @Test
     public void testLogin_Success() {
@@ -73,11 +79,15 @@ public class AuthenticationServiceTest {
                 .password("password123")
                 .build();
         when(authenticationRepository.validateLogin(loginDto.getEmail(), loginDto.getPassword())).thenReturn(true);
+
         // When
-        Map<String, String> response = authenticationService.login(loginDto);
+        LoginResponseDto response = authenticationService.login(loginDto);
+
         // Then
-        assertEquals("로그인 성공", response.get("message"));
+        assertEquals("로그인 성공", response.getMessage());
+        assertEquals(loginDto.getEmail(), response.getUserEmail());
     }
+
 
     @Test
     public void testLogin_Failure() {
@@ -87,6 +97,7 @@ public class AuthenticationServiceTest {
                 .password("wrongPassword")
                 .build();
         when(authenticationRepository.validateLogin(loginDto.getEmail(), loginDto.getPassword())).thenReturn(false);
+
         // When & Then
         assertThrows(CustomException.class, () -> authenticationService.login(loginDto));
     }
@@ -100,10 +111,12 @@ public class AuthenticationServiceTest {
                 .build();
 
         // When
-        Map<String, String> response = authenticationService.resetPassword(passwordChangeDto);
+        ResetPasswordResponseDto response = authenticationService.resetPassword(passwordChangeDto);
 
         // Then
-        assertEquals("비밀번호 재설정 성공", response.get("message"));
+        assertEquals("비밀번호 재설정 성공", response.getMessage());
+        assertEquals("newPassword", response.getNewPassword());
         verify(authenticationRepository).updatePassword(anyString(), eq("newPassword"));
     }
+
 }


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 