### PR TITLE
user - message의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/user/message/controller/MessageController.java
+++ b/api/src/main/java/daehee/challengehub/user/message/controller/MessageController.java
@@ -1,10 +1,11 @@
 package daehee.challengehub.user.message.controller;
 
+import daehee.challengehub.user.message.model.ChatRoomsResponseDto;
+import daehee.challengehub.user.message.model.SendMessageResponseDto;
+import daehee.challengehub.user.message.model.MessageHistoryResponseDto;
 import daehee.challengehub.user.message.service.MessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/message")
@@ -18,17 +19,17 @@ public class MessageController {
     }
 
     @PostMapping("/user/{userId}")
-    public Map<String, Object> sendMessage(@PathVariable Long userId, @RequestBody String messageContent) {
+    public SendMessageResponseDto sendMessage(@PathVariable Long userId, @RequestBody String messageContent) {
         return messageService.sendMessage(userId, messageContent);
     }
 
     @GetMapping("/user/{userId}/messages")
-    public Map<String, Object> getMessageHistory(@PathVariable Long userId) {
+    public MessageHistoryResponseDto getMessageHistory(@PathVariable Long userId) {
         return messageService.getMessageHistory(userId);
     }
 
     @GetMapping("/user/rooms")
-    public Map<String, Object> getChatRooms() {
+    public ChatRoomsResponseDto getChatRooms() {
         return messageService.getChatRooms();
     }
 }

--- a/api/src/main/java/daehee/challengehub/user/message/model/ChatRoomsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/message/model/ChatRoomsResponseDto.java
@@ -1,0 +1,11 @@
+package daehee.challengehub.user.message.model;
+
+import daehee.challengehub.user.message.model.ChatRoomDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatRoomsResponseDto {
+    private final List<ChatRoomDto> chatRooms;
+}

--- a/api/src/main/java/daehee/challengehub/user/message/model/MessageHistoryResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/message/model/MessageHistoryResponseDto.java
@@ -1,0 +1,11 @@
+package daehee.challengehub.user.message.model;
+
+import daehee.challengehub.user.message.model.MessageDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageHistoryResponseDto {
+    private final List<MessageDto> messages;
+}

--- a/api/src/main/java/daehee/challengehub/user/message/model/SendMessageResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/message/model/SendMessageResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.user.message.model;
+
+import daehee.challengehub.user.message.model.MessageDto;
+import lombok.Data;
+
+@Data
+public class SendMessageResponseDto {
+    private final String status;
+    private final MessageDto message;
+}

--- a/api/src/main/java/daehee/challengehub/user/message/service/MessageService.java
+++ b/api/src/main/java/daehee/challengehub/user/message/service/MessageService.java
@@ -1,14 +1,11 @@
 package daehee.challengehub.user.message.service;
 
-import daehee.challengehub.user.message.model.ChatRoomDto;
-import daehee.challengehub.user.message.model.MessageDto;
+import daehee.challengehub.user.message.model.*;
 import daehee.challengehub.user.message.repository.MessageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class MessageService {
@@ -20,33 +17,27 @@ public class MessageService {
     }
 
     // 개인 메시지 전송 로직
-    public Map<String, Object> sendMessage(Long userId, String messageContent) {
+    public SendMessageResponseDto sendMessage(Long userId, String messageContent) {
         // 메시지 생성 및 저장
         MessageDto message = messageRepository.createAndSaveMessage(userId, 456L, messageContent); // 456L은 예시용 리시버 ID
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "메시지 전송 성공");
-        response.put("sentMessage", message);
-        return response;
+        // SendMessageResponseDto 반환
+        return new SendMessageResponseDto("메시지 전송 성공", message);
     }
 
     // 메시지 목록 조회 로직
-    public Map<String, Object> getMessageHistory(Long userId) {
+    public MessageHistoryResponseDto getMessageHistory(Long userId) {
         List<MessageDto> messages = messageRepository.findMessagesByUserId(userId);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "메시지 목록 조회 성공");
-        response.put("messages", messages);
-        return response;
+        // MessageHistoryResponseDto 반환
+        return new MessageHistoryResponseDto(messages);
     }
 
     // 채팅방 목록 조회 로직
-    public Map<String, Object> getChatRooms() {
+    public ChatRoomsResponseDto getChatRooms() {
         List<ChatRoomDto> chatRooms = messageRepository.findAllChatRooms();
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "채팅방 목록 조회 성공");
-        response.put("chatRooms", chatRooms);
-        return response;
+        // ChatRoomsResponseDto 반환
+        return new ChatRoomsResponseDto(chatRooms);
     }
 }

--- a/api/src/test/java/user/service/MessageServiceTest.java
+++ b/api/src/test/java/user/service/MessageServiceTest.java
@@ -1,17 +1,15 @@
 package user.service;
 
-import daehee.challengehub.user.message.model.ChatRoomDto;
-import daehee.challengehub.user.message.model.MessageDto;
+import daehee.challengehub.user.message.model.*;
 import daehee.challengehub.user.message.repository.MessageRepository;
 import daehee.challengehub.user.message.service.MessageService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -34,10 +32,10 @@ public class MessageServiceTest {
         MessageDto mockMessage = new MessageDto(1L, userId, 456L, messageContent, "2023-04-05T15:00:00Z", false, null, null, "text");
         when(messageRepository.createAndSaveMessage(eq(userId), anyLong(), eq(messageContent))).thenReturn(mockMessage);
 
-        Map<String, Object> response = messageService.sendMessage(userId, messageContent);
+        SendMessageResponseDto response = messageService.sendMessage(userId, messageContent);
 
-        assertEquals("메시지 전송 성공", response.get("message"));
-        assertEquals(mockMessage, response.get("sentMessage"));
+        assertEquals("메시지 전송 성공", response.getStatus());
+        assertEquals(mockMessage, response.getMessage());
     }
 
     @Test
@@ -49,10 +47,11 @@ public class MessageServiceTest {
         );
         when(messageRepository.findMessagesByUserId(userId)).thenReturn(mockMessages);
 
-        Map<String, Object> response = messageService.getMessageHistory(userId);
+        MessageHistoryResponseDto response = messageService.getMessageHistory(userId);
 
-        assertEquals("메시지 목록 조회 성공", response.get("message"));
-        assertEquals(mockMessages, response.get("messages"));
+        // TODO: message 필드를 굳이 추가를 해야할까?
+//        assertEquals("메시지 목록 조회 성공", response.getMessage());
+        assertEquals(mockMessages, response.getMessages());
     }
 
     @Test
@@ -63,9 +62,10 @@ public class MessageServiceTest {
         );
         when(messageRepository.findAllChatRooms()).thenReturn(mockChatRooms);
 
-        Map<String, Object> response = messageService.getChatRooms();
+        ChatRoomsResponseDto response = messageService.getChatRooms();
 
-        assertEquals("채팅방 목록 조회 성공", response.get("message"));
-        assertEquals(mockChatRooms, response.get("chatRooms"));
+        // TODO: message 필드를 굳이 추가를 해야할까?
+//        assertEquals("채팅방 목록 조회 성공", response.getMessage());
+        assertEquals(mockChatRooms, response.getChatRooms());
     }
 }


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 