### PR TITLE
user - profile의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/user/profile/controller/ProfileController.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/controller/ProfileController.java
@@ -1,12 +1,9 @@
 package daehee.challengehub.user.profile.controller;
 
-import daehee.challengehub.user.profile.model.PasswordChangeDto;
-import daehee.challengehub.user.profile.model.UserProfileDto;
+import daehee.challengehub.user.profile.model.*;
 import daehee.challengehub.user.profile.service.ProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/profile")
@@ -20,17 +17,17 @@ public class ProfileController {
     }
 
     @GetMapping("/{userId}")
-    public Map<String, Object> getProfile(@PathVariable Long userId) {
+    public ProfileResponseDto getProfile(@PathVariable Long userId) {
         return profileService.getProfile(userId);
     }
 
     @PutMapping
-    public Map<String, String> updateProfile(@RequestBody UserProfileDto userProfileDto) {
+    public UpdateProfileResponseDto updateProfile(@RequestBody UserProfileDto userProfileDto) {
         return profileService.updateProfile(userProfileDto);
     }
 
     @PutMapping("/password")
-    public Map<String, String> changePassword(@RequestBody PasswordChangeDto passwordChangeDto) {
+    public ChangePasswordResponseDto changePassword(@RequestBody PasswordChangeDto passwordChangeDto) {
         return profileService.changePassword(passwordChangeDto);
     }
 
@@ -41,7 +38,8 @@ public class ProfileController {
 //    }
 
     @GetMapping("/{userId}/achievements")
-    public Map<String, Object> getAchievements(@PathVariable Long userId) {
+    public AchievementsResponseDto getAchievements(@PathVariable Long userId) {
         return profileService.getAchievements(userId);
     }
 }
+

--- a/api/src/main/java/daehee/challengehub/user/profile/model/AchievementsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/model/AchievementsResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.user.profile.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AchievementsResponseDto {
+    private final List<AchievementDto> achievements;
+}

--- a/api/src/main/java/daehee/challengehub/user/profile/model/ChangePasswordResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/model/ChangePasswordResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.user.profile.model;
+
+import lombok.Data;
+
+@Data
+public class ChangePasswordResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/user/profile/model/ProfileResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/model/ProfileResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.user.profile.model;
+
+import lombok.Data;
+
+@Data
+public class ProfileResponseDto {
+    private final String message;
+    private final UserProfileDto userProfile;
+}

--- a/api/src/main/java/daehee/challengehub/user/profile/model/UpdateProfileResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/model/UpdateProfileResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.user.profile.model;
+
+import lombok.Data;
+
+@Data
+public class UpdateProfileResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/user/profile/service/ProfileService.java
+++ b/api/src/main/java/daehee/challengehub/user/profile/service/ProfileService.java
@@ -2,16 +2,12 @@ package daehee.challengehub.user.profile.service;
 
 import daehee.challengehub.common.constants.ErrorCode;
 import daehee.challengehub.common.exception.CustomException;
-import daehee.challengehub.user.profile.model.AchievementDto;
-import daehee.challengehub.user.profile.model.PasswordChangeDto;
-import daehee.challengehub.user.profile.model.UserProfileDto;
+import daehee.challengehub.user.profile.model.*;
 import daehee.challengehub.user.profile.repository.ProfileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class ProfileService {
@@ -24,41 +20,31 @@ public class ProfileService {
     }
 
     // 사용자 프로필 조회 로직
-    public Map<String, Object> getProfile(Long userId) {
+    public ProfileResponseDto getProfile(Long userId) {
         UserProfileDto userProfile = profileRepository.findProfileByUserId(userId);
         if (userProfile != null) {
-            Map<String, Object> response = new HashMap<>();
-            response.put("message", "프로필 조회 성공");
-            response.put("profile", userProfile);
-            response.put("isCurrentUser", userId.equals(loggedInUserId));
-            return response;
+            return new ProfileResponseDto("프로필 조회 성공", userProfile);
         } else {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
     }
 
     // 프로필 정보 업데이트 로직
-    public Map<String, String> updateProfile(UserProfileDto userProfileDto) {
+    public UpdateProfileResponseDto updateProfile(UserProfileDto userProfileDto) {
         profileRepository.updateProfile(userProfileDto.getUserId(), userProfileDto);
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "프로필 업데이트 성공");
-        return response;
+        return new UpdateProfileResponseDto("프로필 업데이트 성공");
     }
 
     // 비밀번호 변경 로직
-    public Map<String, String> changePassword(PasswordChangeDto passwordChangeDto) {
+    public ChangePasswordResponseDto changePassword(PasswordChangeDto passwordChangeDto) {
         // TODO: AuthenticationService에 구현한 로직과 중복되므로 검토 후 하나를 제거
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "비밀번호 변경 성공");
-        return response;
+        return new ChangePasswordResponseDto("비밀번호 변경 성공");
     }
 
     // 성과 목록 조회 로직
-    public Map<String, Object> getAchievements(Long userId) {
+    public AchievementsResponseDto getAchievements(Long userId) {
         List<AchievementDto> userAchievements = profileRepository.findAchievementsByUserId(userId);
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "성과 목록 조회 성공");
-        response.put("achievements", userAchievements);
-        return response;
+        return new AchievementsResponseDto(userAchievements);
     }
 }
+

--- a/api/src/test/java/user/service/ProfileServiceTest.java
+++ b/api/src/test/java/user/service/ProfileServiceTest.java
@@ -1,9 +1,7 @@
 package user.service;
 
 import daehee.challengehub.common.exception.CustomException;
-import daehee.challengehub.user.profile.model.AchievementDto;
-import daehee.challengehub.user.profile.model.PasswordChangeDto;
-import daehee.challengehub.user.profile.model.UserProfileDto;
+import daehee.challengehub.user.profile.model.*;
 import daehee.challengehub.user.profile.repository.ProfileRepository;
 import daehee.challengehub.user.profile.service.ProfileService;
 import org.junit.jupiter.api.Test;
@@ -14,9 +12,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,11 +32,10 @@ public class ProfileServiceTest {
         UserProfileDto mockProfile = new UserProfileDto(userId, "sampleUser", "SampleNickname", "user@example.com", "Sample bio");
         when(profileRepository.findProfileByUserId(userId)).thenReturn(mockProfile);
 
-        Map<String, Object> response = profileService.getProfile(userId);
+        ProfileResponseDto response = profileService.getProfile(userId);
 
-        assertEquals("프로필 조회 성공", response.get("message"));
-        assertEquals(mockProfile, response.get("profile"));
-        assertTrue((Boolean) response.get("isCurrentUser"));
+        assertEquals("프로필 조회 성공", response.getMessage());
+        assertEquals(mockProfile, response.getUserProfile());
     }
 
     @Test
@@ -54,9 +51,9 @@ public class ProfileServiceTest {
         UserProfileDto updatedProfile = new UserProfileDto(1L, "updatedUser", "UpdatedNickname", "updated@example.com", "Updated bio");
         doNothing().when(profileRepository).updateProfile(eq(1L), any(UserProfileDto.class));
 
-        Map<String, String> response = profileService.updateProfile(updatedProfile);
+        UpdateProfileResponseDto response = profileService.updateProfile(updatedProfile);
 
-        assertEquals("프로필 업데이트 성공", response.get("message"));
+        assertEquals("프로필 업데이트 성공", response.getMessage());
         verify(profileRepository).updateProfile(eq(1L), any(UserProfileDto.class));
     }
 
@@ -66,10 +63,9 @@ public class ProfileServiceTest {
         List<AchievementDto> achievements = Arrays.asList(new AchievementDto(userId, 101L, "10일 연속 챌린지 완료", "2023-01-10"));
         when(profileRepository.findAchievementsByUserId(userId)).thenReturn(achievements);
 
-        Map<String, Object> response = profileService.getAchievements(userId);
+        AchievementsResponseDto response = profileService.getAchievements(userId);
 
-        assertEquals("성과 목록 조회 성공", response.get("message"));
-        assertEquals(achievements, response.get("achievements"));
+        assertEquals(achievements, response.getAchievements());
         verify(profileRepository).findAchievementsByUserId(userId);
     }
 
@@ -77,9 +73,9 @@ public class ProfileServiceTest {
     public void changePassword_UpdatesPassword_ReturnsSuccessMessage() {
         PasswordChangeDto passwordChangeDto = new PasswordChangeDto("oldPassword", "newPassword");
 
-        Map<String, String> response = profileService.changePassword(passwordChangeDto);
+        ChangePasswordResponseDto response = profileService.changePassword(passwordChangeDto);
 
-        assertEquals("비밀번호 변경 성공", response.get("message"));
-        // 여기서는 실제 Repository 호출이 없기 때문에 verify() 호출은 필요 없습니다.
+        assertEquals("비밀번호 변경 성공", response.getMessage());
     }
 }
+


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 