### PR TITLE
social - community의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/social/community/controller/CommunityController.java
+++ b/api/src/main/java/daehee/challengehub/social/community/controller/CommunityController.java
@@ -1,11 +1,9 @@
 package daehee.challengehub.social.community.controller;
 
-import daehee.challengehub.social.community.model.CommunityPostDto;
+import daehee.challengehub.social.community.model.*;
 import daehee.challengehub.social.community.service.CommunityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/community")
@@ -18,32 +16,32 @@ public class CommunityController {
     }
 
     @GetMapping("/feed")
-    public Map<String, Object> getCommunityFeed() {
+    public CommunityFeedResponseDto getCommunityFeed() {
         return communityService.getCommunityFeed();
     }
 
     @PostMapping("/posts")
-    public Map<String, Object> createCommunityPost(@RequestBody CommunityPostDto communityPostDto) {
+    public CreatePostResponseDto createCommunityPost(@RequestBody CommunityPostDto communityPostDto) {
         return communityService.createCommunityPost(communityPostDto);
     }
 
     @PutMapping("/posts/{postId}")
-    public Map<String, Object> updatePost(@PathVariable Long postId, @RequestBody CommunityPostDto postUpdateData) {
+    public UpdatePostResponseDto updatePost(@PathVariable Long postId, @RequestBody CommunityPostDto postUpdateData) {
         return communityService.updatePost(postId, postUpdateData);
     }
 
     @DeleteMapping("/posts/{postId}")
-    public Map<String, String> deletePost(@PathVariable Long postId) {
+    public DeletePostResponseDto deletePost(@PathVariable Long postId) {
         return communityService.deletePost(postId);
     }
 
     @GetMapping("/posts")
-    public Map<String, Object> getCommunityPosts() {
+    public CommunityFeedResponseDto getCommunityPosts() {
         return communityService.getCommunityPosts();
     }
 
     @PostMapping("/posts/{postId}/like")
-    public Map<String, Object> likeCommunityPost(@PathVariable Long postId) {
+    public LikePostResponseDto likeCommunityPost(@PathVariable Long postId) {
         return communityService.likeCommunityPost(postId);
     }
 }

--- a/api/src/main/java/daehee/challengehub/social/community/model/CommunityFeedResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/community/model/CommunityFeedResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.social.community.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CommunityFeedResponseDto {
+    private final List<CommunityPostDto> posts;
+}

--- a/api/src/main/java/daehee/challengehub/social/community/model/CreatePostResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/community/model/CreatePostResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.social.community.model;
+
+import lombok.Data;
+
+@Data
+public class CreatePostResponseDto {
+    private final String message;
+    private final CommunityPostDto post;
+}

--- a/api/src/main/java/daehee/challengehub/social/community/model/DeletePostResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/community/model/DeletePostResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.social.community.model;
+
+import lombok.Data;
+
+@Data
+public class DeletePostResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/social/community/model/LikePostResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/community/model/LikePostResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.social.community.model;
+
+import lombok.Data;
+
+@Data
+public class LikePostResponseDto {
+    private final String message;
+    private final int newLikeCount;
+}

--- a/api/src/main/java/daehee/challengehub/social/community/model/UpdatePostResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/community/model/UpdatePostResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.social.community.model;
+
+import lombok.Data;
+
+@Data
+public class UpdatePostResponseDto {
+    private final String message;
+    private final CommunityPostDto updatedPost;
+}

--- a/api/src/main/java/daehee/challengehub/social/community/service/CommunityService.java
+++ b/api/src/main/java/daehee/challengehub/social/community/service/CommunityService.java
@@ -1,13 +1,11 @@
 package daehee.challengehub.social.community.service;
 
-import daehee.challengehub.social.community.model.CommunityPostDto;
+import daehee.challengehub.social.community.model.*;
 import daehee.challengehub.social.community.repository.CommunityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class CommunityService {
@@ -19,59 +17,39 @@ public class CommunityService {
     }
 
     // 커뮤니티 피드 조회 로직
-    // TODO: 생각해보니까 피드 보는 거는 게시글 1개 보는 걸 하려고 했는데 기능상 굳이 필요 없을 거 같기도 하다.
-    // TODO: 둘중 하나 남기거나 URL 수정해서 1개만 보는 걸로 바꿔야할 거 같다.
-    public Map<String, Object> getCommunityFeed() {
+    public CommunityFeedResponseDto getCommunityFeed() {
         List<CommunityPostDto> communityFeed = communityRepository.getAllPosts();
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "커뮤니티 피드 조회 성공");
-        response.put("communityFeed", communityFeed);
-        return response;
+        return new CommunityFeedResponseDto(communityFeed);
     }
 
     // 커뮤니티 포스트 작성 로직
-    public Map<String, Object> createCommunityPost(CommunityPostDto communityPostDto) {
+    public CreatePostResponseDto createCommunityPost(CommunityPostDto communityPostDto) {
         communityRepository.savePost(communityPostDto);
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "커뮤니티 포스트 생성 성공");
-        response.put("createdPost", communityPostDto);
-        return response;
+        return new CreatePostResponseDto("커뮤니티 포스트 생성 성공", communityPostDto);
     }
 
     // 커뮤니티 포스트 수정 로직
-    public Map<String, Object> updatePost(Long postId, CommunityPostDto postUpdateData) {
+    public UpdatePostResponseDto updatePost(Long postId, CommunityPostDto postUpdateData) {
         communityRepository.updatePost(postId, postUpdateData);
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "커뮤니티 포스트 수정 성공");
-        response.put("updatedPost", postUpdateData);
-        return response;
+        return new UpdatePostResponseDto("커뮤니티 포스트 수정 성공", postUpdateData);
     }
 
     // 커뮤니티 포스트 삭제 로직
-    public Map<String, String> deletePost(Long postId) {
+    public DeletePostResponseDto deletePost(Long postId) {
         communityRepository.deletePost(postId);
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "포스트 삭제 성공: 포스트 ID " + postId);
-        return response;
+        return new DeletePostResponseDto("포스트 삭제 성공: 포스트 ID " + postId);
     }
 
     // 커뮤니티 포스트 목록 조회 로직
-    public Map<String, Object> getCommunityPosts() {
+    public CommunityFeedResponseDto getCommunityPosts() {
         List<CommunityPostDto> posts = communityRepository.getAllPosts();
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "커뮤니티 포스트 목록 조회 성공");
-        response.put("posts", posts);
-        return response;
+        return new CommunityFeedResponseDto(posts);
     }
 
     // 포스트 좋아요 로직
-    // TODO: 좋아요 관련 로직 구현이 단순히 1만 증가한다고 되는건지 다시 검토하기
-    public Map<String, Object> likeCommunityPost(Long postId) {
+    public LikePostResponseDto likeCommunityPost(Long postId) {
         communityRepository.likePost(postId);
         CommunityPostDto likedPost = communityRepository.findPostById(postId);
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", String.format("포스트 ID %d에 좋아요 성공", postId));
-        response.put("likedPost", likedPost);
-        return response;
+        return new LikePostResponseDto(String.format("포스트 ID %d에 좋아요 성공", postId), likedPost.getLikeCount());
     }
 }

--- a/api/src/test/java/social/service/CommunityServiceTest.java
+++ b/api/src/test/java/social/service/CommunityServiceTest.java
@@ -1,24 +1,19 @@
 package social.service;
 
-import daehee.challengehub.social.community.model.CommunityPostDto;
+import daehee.challengehub.social.community.model.*;
 import daehee.challengehub.social.community.repository.CommunityRepository;
 import daehee.challengehub.social.community.service.CommunityService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CommunityServiceTest {
@@ -57,11 +52,10 @@ public class CommunityServiceTest {
         when(communityRepository.getAllPosts()).thenReturn(mockPosts);
 
         // When
-        Map<String, Object> response = communityService.getCommunityFeed();
+        CommunityFeedResponseDto response = communityService.getCommunityFeed();
 
         // Then
-        assertEquals("커뮤니티 피드 조회 성공", response.get("message"));
-        assertEquals(mockPosts, response.get("communityFeed"));
+        assertEquals(mockPosts, response.getPosts());
     }
 
     @Test
@@ -80,13 +74,12 @@ public class CommunityServiceTest {
         doNothing().when(communityRepository).savePost(any(CommunityPostDto.class));
 
         // When
-        Map<String, Object> response = communityService.createCommunityPost(newPost);
+        CreatePostResponseDto response = communityService.createCommunityPost(newPost);
 
         // Then
-        assertEquals("커뮤니티 포스트 생성 성공", response.get("message"));
+        assertEquals("커뮤니티 포스트 생성 성공", response.getMessage());
         verify(communityRepository).savePost(any(CommunityPostDto.class));
     }
-
 
     @Test
     public void updatePost_UpdatesExistingPost() {
@@ -105,10 +98,10 @@ public class CommunityServiceTest {
         doNothing().when(communityRepository).updatePost(eq(postId), any(CommunityPostDto.class));
 
         // When
-        Map<String, Object> response = communityService.updatePost(postId, updatedPost);
+        UpdatePostResponseDto response = communityService.updatePost(postId, updatedPost);
 
         // Then
-        assertEquals("커뮤니티 포스트 수정 성공", response.get("message"));
+        assertEquals("커뮤니티 포스트 수정 성공", response.getMessage());
         verify(communityRepository).updatePost(eq(postId), any(CommunityPostDto.class));
     }
 
@@ -119,10 +112,10 @@ public class CommunityServiceTest {
         doNothing().when(communityRepository).deletePost(postId);
 
         // When
-        Map<String, String> response = communityService.deletePost(postId);
+        DeletePostResponseDto response = communityService.deletePost(postId);
 
         // Then
-        assertEquals("포스트 삭제 성공: 포스트 ID " + postId, response.get("message"));
+        assertEquals("포스트 삭제 성공: 포스트 ID " + postId, response.getMessage());
         verify(communityRepository).deletePost(postId);
     }
 
@@ -154,11 +147,10 @@ public class CommunityServiceTest {
         when(communityRepository.getAllPosts()).thenReturn(mockPosts);
 
         // When
-        Map<String, Object> response = communityService.getCommunityPosts();
+        CommunityFeedResponseDto response = communityService.getCommunityPosts();
 
         // Then
-        assertEquals("커뮤니티 포스트 목록 조회 성공", response.get("message"));
-        assertEquals(mockPosts, response.get("posts"));
+        assertEquals(mockPosts, response.getPosts());
     }
 
     @Test
@@ -178,13 +170,12 @@ public class CommunityServiceTest {
         when(communityRepository.findPostById(postId)).thenReturn(likedPost);
         doNothing().when(communityRepository).likePost(postId);
 
-
         // When
-        Map<String, Object> response = communityService.likeCommunityPost(postId);
+        LikePostResponseDto response = communityService.likeCommunityPost(postId);
 
         // Then
-        assertEquals(String.format("포스트 ID %d에 좋아요 성공", postId), response.get("message"));
-        assertEquals(likedPost, response.get("likedPost"));
+        assertEquals(String.format("포스트 ID %d에 좋아요 성공", postId), response.getMessage());
+        assertEquals(likedPost.getLikeCount(), response.getNewLikeCount());
         verify(communityRepository).likePost(postId);
     }
 }


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 