### PR TITLE
social - network의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/social/network/controller/NetworkController.java
+++ b/api/src/main/java/daehee/challengehub/social/network/controller/NetworkController.java
@@ -1,10 +1,12 @@
 package daehee.challengehub.social.network.controller;
 
+import daehee.challengehub.social.network.model.FollowResponseDto;
+import daehee.challengehub.social.network.model.FollowersResponseDto;
+import daehee.challengehub.social.network.model.FollowingResponseDto;
+import daehee.challengehub.social.network.model.UnfollowResponseDto;
 import daehee.challengehub.social.network.service.NetworkService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/network")
@@ -16,26 +18,23 @@ public class NetworkController {
         this.networkService = networkService;
     }
 
-
-    // TODO: URL 수정한 거 정리해서 반영하기
-
     @PostMapping("/follow/{followerId}/{followingId}")
-    public Map<String, Object> followUser(@PathVariable Long followerId, @PathVariable Long followingId) {
+    public FollowResponseDto followUser(@PathVariable Long followerId, @PathVariable Long followingId) {
         return networkService.followUser(followerId, followingId);
     }
 
     @GetMapping("/following/{userId}")
-    public Map<String, Object> getFollowings(@PathVariable Long userId) {
+    public FollowingResponseDto getFollowings(@PathVariable Long userId) {
         return networkService.getFollowings(userId);
     }
 
     @DeleteMapping("/unfollow/{followerId}/{followingId}")
-    public Map<String, String> unfollowUser(@PathVariable Long followerId, @PathVariable Long followingId) {
+    public UnfollowResponseDto unfollowUser(@PathVariable Long followerId, @PathVariable Long followingId) {
         return networkService.unfollowUser(followerId, followingId);
     }
 
     @GetMapping("/followers/{userId}")
-    public Map<String, Object> getFollowers(@PathVariable Long userId) {
+    public FollowersResponseDto getFollowers(@PathVariable Long userId) {
         return networkService.getFollowers(userId);
     }
 }

--- a/api/src/main/java/daehee/challengehub/social/network/model/FollowResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/network/model/FollowResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.social.network.model;
+
+import lombok.Data;
+
+@Data
+public class FollowResponseDto {
+    private final String message;
+    private final FollowDto followDetails;
+}

--- a/api/src/main/java/daehee/challengehub/social/network/model/FollowersResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/network/model/FollowersResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.social.network.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FollowersResponseDto {
+    private final List<FollowersDto> followers;
+}

--- a/api/src/main/java/daehee/challengehub/social/network/model/FollowingResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/network/model/FollowingResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.social.network.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FollowingResponseDto {
+    private final List<FollowDto> followings;
+}

--- a/api/src/main/java/daehee/challengehub/social/network/model/UnfollowResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/social/network/model/UnfollowResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.social.network.model;
+
+import lombok.Data;
+
+@Data
+public class UnfollowResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/social/network/service/NetworkService.java
+++ b/api/src/main/java/daehee/challengehub/social/network/service/NetworkService.java
@@ -1,14 +1,11 @@
 package daehee.challengehub.social.network.service;
 
-import daehee.challengehub.social.network.model.FollowDto;
-import daehee.challengehub.social.network.model.FollowersDto;
+import daehee.challengehub.social.network.model.*;
 import daehee.challengehub.social.network.repository.NetworkRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,59 +19,38 @@ public class NetworkService {
         this.networkRepository = networkRepository;
     }
 
-    public Map<String, Object> followUser(Long followerId, Long followingId) {
+    public FollowResponseDto followUser(Long followerId, Long followingId) {
         networkRepository.followUser(followerId, followingId);
         boolean isMutual = networkRepository.getFollowers(followingId).contains(followerId);
+        FollowDto newFollow = createFollowDto(followerId, followingId);
 
-        FollowDto newFollow = FollowDto.builder()
-                .followerId(followerId)
-                .followingId(followingId)
-                .followDate("2023-11-15")
-                .isMutual(isMutual)
-                .followerUsername("follower_username")
-                .followingUsername("following_username")
-                .followerProfileImage("https://example.com/follower_image.jpg")
-                .followingProfileImage("https://example.com/following_image.jpg")
-                .build();
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", String.format("사용자 %d 팔로우 성공. 상호 팔로우 상태: %s", followingId, isMutual ? "예" : "아니오"));
-        response.put("followDetails", newFollow);
-        return response;
+        return new FollowResponseDto(
+                String.format("사용자 %d 팔로우 성공. 상호 팔로우 상태: %s", followingId, isMutual ? "예" : "아니오"),
+                newFollow
+        );
     }
 
-    public Map<String, Object> getFollowings(Long userId) {
+    public FollowingResponseDto getFollowings(Long userId) {
         Set<Long> followingIds = networkRepository.getFollowings(userId);
-        // 실제 팔로잉 ID 목록에 기반하여 FollowDto 리스트 생성
         List<FollowDto> followingList = followingIds.stream()
-                .map(followingId -> createFollowDto(userId, followingId)) // 이 메서드는 실제 FollowDto 생성 로직을 포함해야 함
+                .map(followingId -> createFollowDto(userId, followingId))
                 .collect(Collectors.toList());
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "팔로잉 목록 조회 성공");
-        response.put("followingList", followingList);
-        return response;
+        return new FollowingResponseDto(followingList);
     }
 
-    public Map<String, String> unfollowUser(Long followerId, Long followingId) {
+    public UnfollowResponseDto unfollowUser(Long followerId, Long followingId) {
         networkRepository.unfollowUser(followerId, followingId);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", String.format("사용자 ID %d 언팔로우 성공", followingId));
-        return response;
+        return new UnfollowResponseDto(String.format("사용자 ID %d 언팔로우 성공", followingId));
     }
 
-    public Map<String, Object> getFollowers(Long userId) {
+    public FollowersResponseDto getFollowers(Long userId) {
         Set<Long> followerIds = networkRepository.getFollowers(userId);
-        // 실제 팔로워 ID 목록에 기반하여 FollowersDto 리스트 생성
         List<FollowersDto> followers = followerIds.stream()
-                .map(this::createFollowersDto) // 이 메서드는 실제 FollowersDto 생성 로직을 포함해야 함
+                .map(this::createFollowersDto)
                 .collect(Collectors.toList());
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "팔로워 목록 조회 성공");
-        response.put("followers", followers);
-        return response;
+        return new FollowersResponseDto(followers);
     }
 
     private FollowDto createFollowDto(Long followerId, Long followingId) {

--- a/api/src/test/java/social/service/NetworkServiceTest.java
+++ b/api/src/test/java/social/service/NetworkServiceTest.java
@@ -1,22 +1,23 @@
 package social.service;
 
+import daehee.challengehub.social.network.model.FollowResponseDto;
+import daehee.challengehub.social.network.model.FollowersResponseDto;
+import daehee.challengehub.social.network.model.FollowingResponseDto;
+import daehee.challengehub.social.network.model.UnfollowResponseDto;
 import daehee.challengehub.social.network.repository.NetworkRepository;
 import daehee.challengehub.social.network.service.NetworkService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
-import java.util.Set;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class NetworkServiceTest {
@@ -35,7 +36,7 @@ public class NetworkServiceTest {
         doNothing().when(networkRepository).followUser(followerId, followingId);
 
         // When
-        Map<String, Object> response = networkService.followUser(followerId, followingId);
+        FollowResponseDto response = networkService.followUser(followerId, followingId);
 
         // Then
         assertNotNull(response);
@@ -50,7 +51,7 @@ public class NetworkServiceTest {
         when(networkRepository.getFollowings(userId)).thenReturn(followingIds);
 
         // When
-        Map<String, Object> response = networkService.getFollowings(userId);
+        FollowingResponseDto response = networkService.getFollowings(userId);
 
         // Then
         assertNotNull(response);
@@ -65,7 +66,7 @@ public class NetworkServiceTest {
         doNothing().when(networkRepository).unfollowUser(followerId, followingId);
 
         // When
-        Map<String, String> response = networkService.unfollowUser(followerId, followingId);
+        UnfollowResponseDto response = networkService.unfollowUser(followerId, followingId);
 
         // Then
         assertNotNull(response);
@@ -80,7 +81,7 @@ public class NetworkServiceTest {
         when(networkRepository.getFollowers(userId)).thenReturn(followerIds);
 
         // When
-        Map<String, Object> response = networkService.getFollowers(userId);
+        FollowersResponseDto response = networkService.getFollowers(userId);
 
         // Then
         assertNotNull(response);


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 