### PR TITLE
challenge - interaction의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/challenge/interaction/controller/InteractionController.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/controller/InteractionController.java
@@ -1,11 +1,9 @@
 package daehee.challengehub.challenge.interaction.controller;
 
-import daehee.challengehub.challenge.interaction.model.ChallengeParticipantDto;
+import daehee.challengehub.challenge.interaction.model.*;
 import daehee.challengehub.challenge.interaction.service.InteractionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/challenges")
@@ -18,27 +16,27 @@ public class InteractionController {
     }
 
     @PostMapping("/{id}/comments")
-    public Map<String, Object> postComment(@PathVariable Long id, @RequestBody String commentText) {
+    public PostCommentResponseDto postComment(@PathVariable Long id, @RequestBody String commentText) {
         return interactionService.postComment(id, commentText);
     }
 
     @GetMapping("/{id}/comments")
-    public Map<String, Object> getComments(@PathVariable Long id) {
+    public CommentsResponseDto getComments(@PathVariable Long id) {
         return interactionService.getComments(id);
     }
 
     @GetMapping("/{id}/leaderboard")
-    public Map<String, Object> getLeaderboard(@PathVariable Long id) {
+    public LeaderboardResponseDto getLeaderboard(@PathVariable Long id) {
         return interactionService.getLeaderboard(id);
     }
 
     @GetMapping("/{id}/participants/details")
-    public Map<String, Object> getParticipantDetails(@PathVariable Long id) {
+    public ParticipantDetailsResponseDto getParticipantDetails(@PathVariable Long id) {
         return interactionService.getParticipantDetails(id);
     }
 
     @PostMapping("/{id}/participants/manage")
-    public Map<String, String> manageParticipants(@PathVariable Long id, @RequestBody ChallengeParticipantDto participantData) {
+    public ManageParticipantsResponseDto manageParticipants(@PathVariable Long id, @RequestBody ChallengeParticipantDto participantData) {
         return interactionService.manageParticipants(id, participantData);
     }
 }

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/CommentsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/CommentsResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CommentsResponseDto {
+    private final List<ChallengeCommentDto> comments;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/LeaderboardResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/LeaderboardResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class LeaderboardResponseDto {
+    private final List<ParticipantScoreDto> leaderboard; // ParticipantScoreDto는 리더보드에 필요한 데이터를 포함
+}

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/ManageParticipantsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/ManageParticipantsResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.Data;
+
+@Data
+public class ManageParticipantsResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/ParticipantDetailsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/ParticipantDetailsResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ParticipantDetailsResponseDto {
+    private final List<ChallengeParticipantDto> participants;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/ParticipantScoreDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/ParticipantScoreDto.java
@@ -1,0 +1,17 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ParticipantScoreDto {
+    private final Long participantId; // 참가자의 사용자 ID
+    private final String participantUsername; // 참가자의 사용자명
+    private final int score; // 참가자의 점수
+    private final String rank; // 참가자의 순위
+    private final String participantProfileImage; // 참가자의 프로필 이미지 URL
+}
+

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/model/PostCommentResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/model/PostCommentResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.interaction.model;
+
+import lombok.Data;
+
+@Data
+public class PostCommentResponseDto {
+    private final String message;
+    private final ChallengeCommentDto comment;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/repository/InteractionRepository.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/repository/InteractionRepository.java
@@ -2,12 +2,14 @@ package daehee.challengehub.challenge.interaction.repository;
 
 import daehee.challengehub.challenge.interaction.model.ChallengeCommentDto;
 import daehee.challengehub.challenge.interaction.model.ChallengeParticipantDto;
+import daehee.challengehub.challenge.interaction.model.ParticipantScoreDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 public class InteractionRepository {
@@ -86,9 +88,25 @@ public class InteractionRepository {
         return challengeComments.getOrDefault(challengeId, new ArrayList<>());
     }
 
-    public List<ChallengeParticipantDto> getLeaderboard(Long challengeId) {
-        return challengeLeaderboards.getOrDefault(challengeId, new ArrayList<>());
+    public List<ParticipantScoreDto> getLeaderboard(Long challengeId) {
+        List<ChallengeParticipantDto> participants = challengeLeaderboards.getOrDefault(challengeId, new ArrayList<>());
+
+        // ChallengeParticipantDto 객체를 ParticipantScoreDto 객체로 변환
+        return participants.stream()
+                .map(this::convertToParticipantScoreDto)
+                .collect(Collectors.toList());
     }
+
+    private ParticipantScoreDto convertToParticipantScoreDto(ChallengeParticipantDto participant) {
+        // 이 메소드는 ChallengeParticipantDto 객체를 받아 ParticipantScoreDto 객체를 생성합니다.
+        // 예시 구현은 단순화를 위해 일부 필드만 사용하며, 실제 필요한 데이터에 따라 변경될 수 있습니다.
+        return ParticipantScoreDto.builder()
+                .participantId(participant.getParticipantId())
+                .participantUsername(participant.getParticipantUsername())
+                // 여기에 추가로 점수, 순위 등의 필드를 계산하거나 설정
+                .build();
+    }
+
 
     public List<ChallengeParticipantDto> getParticipants(Long challengeId) {
         return challengeParticipants.getOrDefault(challengeId, new ArrayList<>());

--- a/api/src/main/java/daehee/challengehub/challenge/interaction/service/InteractionService.java
+++ b/api/src/main/java/daehee/challengehub/challenge/interaction/service/InteractionService.java
@@ -1,15 +1,12 @@
 package daehee.challengehub.challenge.interaction.service;
 
-import daehee.challengehub.challenge.interaction.model.ChallengeCommentDto;
-import daehee.challengehub.challenge.interaction.model.ChallengeParticipantDto;
+import daehee.challengehub.challenge.interaction.model.*;
 import daehee.challengehub.challenge.interaction.repository.InteractionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class InteractionService {
@@ -22,7 +19,7 @@ public class InteractionService {
     }
 
     // 챌린지에 대한 댓글 작성 로직
-    public Map<String, Object> postComment(Long id, String commentText) {
+    public PostCommentResponseDto postComment(Long id, String commentText) {
         ChallengeCommentDto newComment = ChallengeCommentDto.builder()
                 .challengeId(id)
                 .userId(123L) // 예시: 현재 로그인한 사용자 ID
@@ -31,50 +28,32 @@ public class InteractionService {
                 .build();
 
         interactionRepository.postComment(id, newComment);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "댓글 작성 성공");
-        response.put("comment", newComment);
-        return response;
+        return new PostCommentResponseDto("댓글 작성 성공", newComment);
     }
 
     // 챌린지 댓글 목록 조회 로직
-    public Map<String, Object> getComments(Long id) {
+    public CommentsResponseDto getComments(Long id) {
         List<ChallengeCommentDto> comments = interactionRepository.getComments(id);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "댓글 목록 조회 성공");
-        response.put("comments", comments);
-        return response;
+        return new CommentsResponseDto(comments);
     }
 
     // 챌린지별 리더보드 조회 로직
-    public Map<String, Object> getLeaderboard(Long id) {
-        List<ChallengeParticipantDto> leaderboard = interactionRepository.getLeaderboard(id);
+    public LeaderboardResponseDto getLeaderboard(Long id) {
+        // interactionRepository.getLeaderboard(id)가 List<ParticipantScoreDto>를 반환하도록 가정
+        List<ParticipantScoreDto> leaderboard = interactionRepository.getLeaderboard(id);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "리더보드 조회 성공");
-        response.put("leaderboard", leaderboard);
-        return response;
+        return new LeaderboardResponseDto(leaderboard);
     }
 
     // 참여자 상세 정보 조회 로직
-    public Map<String, Object> getParticipantDetails(Long id) {
+    public ParticipantDetailsResponseDto getParticipantDetails(Long id) {
         List<ChallengeParticipantDto> participants = interactionRepository.getParticipants(id);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "참여자 상세 정보 조회 성공");
-        response.put("participants", participants);
-        return response;
+        return new ParticipantDetailsResponseDto(participants);
     }
 
-    // 참여자 관리 로직 (인증이 안된 경우 추방하는 기능은 미구현 상태)
-    public Map<String, String> manageParticipants(Long id, ChallengeParticipantDto participantData) {
+    // 참여자 관리 로직
+    public ManageParticipantsResponseDto manageParticipants(Long id, ChallengeParticipantDto participantData) {
         // TODO: 참여자 관리 로직 구현
-        // 현재는 단순한 메시지 반환으로 처리
-        Map<String, String> response = new HashMap<>();
-        response.put("message", String.format("챌린지 ID %d에 대한 참여자 관리 성공", id));
-        return response;
+        return new ManageParticipantsResponseDto(String.format("챌린지 ID %d에 대한 참여자 관리 성공", id));
     }
 }
-

--- a/api/src/test/java/challenge/service/InteractionServiceTest.java
+++ b/api/src/test/java/challenge/service/InteractionServiceTest.java
@@ -1,25 +1,19 @@
 package challenge.service;
 
-import daehee.challengehub.challenge.interaction.model.ChallengeCommentDto;
-import daehee.challengehub.challenge.interaction.model.ChallengeParticipantDto;
+import daehee.challengehub.challenge.interaction.model.*;
 import daehee.challengehub.challenge.interaction.repository.InteractionRepository;
 import daehee.challengehub.challenge.interaction.service.InteractionService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class InteractionServiceTest {
@@ -39,10 +33,10 @@ public class InteractionServiceTest {
         doNothing().when(interactionRepository).postComment(eq(challengeId), any(ChallengeCommentDto.class));
 
         // When
-        Map<String, Object> response = interactionService.postComment(challengeId, commentText);
+        PostCommentResponseDto response = interactionService.postComment(challengeId, commentText);
 
         // Then
-        assertEquals("댓글 작성 성공", response.get("message"));
+        assertEquals("댓글 작성 성공", response.getMessage());
         verify(interactionRepository).postComment(eq(challengeId), any(ChallengeCommentDto.class));
     }
 
@@ -69,39 +63,38 @@ public class InteractionServiceTest {
         when(interactionRepository.getComments(challengeId)).thenReturn(mockComments);
 
         // When
-        Map<String, Object> response = interactionService.getComments(challengeId);
+        CommentsResponseDto response = interactionService.getComments(challengeId);
 
         // Then
-        assertEquals("댓글 목록 조회 성공", response.get("message"));
-        assertEquals(mockComments, response.get("comments"));
+//        assertEquals("댓글 목록 조회 성공", response.getMessage());
+        assertEquals(mockComments, response.getComments());
     }
 
     @Test
     public void getLeaderboard_RetrievesLeaderboardSuccessfully() {
         // Given
         Long challengeId = 3L;
-        List<ChallengeParticipantDto> mockLeaderboard = Arrays.asList(
-                ChallengeParticipantDto.builder()
+        List<ParticipantScoreDto> mockLeaderboard = Arrays.asList(
+                ParticipantScoreDto.builder()
                         .participantId(1L)
-                        .challengeId(3L)
                         .participantUsername("user1")
-                        .joinedAt("2023-11-14")
+                        .score(100)
+                        .rank("1")
                         .build(),
-                ChallengeParticipantDto.builder()
+                ParticipantScoreDto.builder()
                         .participantId(2L)
-                        .challengeId(4L)
                         .participantUsername("user2")
-                        .joinedAt("2023-11-14")
+                        .score(90)
+                        .rank("2")
                         .build()
         );
         when(interactionRepository.getLeaderboard(challengeId)).thenReturn(mockLeaderboard);
 
         // When
-        Map<String, Object> response = interactionService.getLeaderboard(challengeId);
+        LeaderboardResponseDto response = interactionService.getLeaderboard(challengeId);
 
         // Then
-        assertEquals("리더보드 조회 성공", response.get("message"));
-        assertEquals(mockLeaderboard, response.get("leaderboard"));
+        assertEquals(mockLeaderboard, response.getLeaderboard());
     }
 
     @Test
@@ -125,11 +118,11 @@ public class InteractionServiceTest {
         when(interactionRepository.getParticipants(challengeId)).thenReturn(mockParticipants);
 
         // When
-        Map<String, Object> response = interactionService.getParticipantDetails(challengeId);
+        ParticipantDetailsResponseDto response = interactionService.getParticipantDetails(challengeId);
 
         // Then
-        assertEquals("참여자 상세 정보 조회 성공", response.get("message"));
-        assertEquals(mockParticipants, response.get("participants"));
+//        assertEquals("참여자 상세 정보 조회 성공", response.getMessage());
+        assertEquals(mockParticipants, response.getParticipants());
     }
 
     // TODO: manageParticipants 메서드의 테스트 구현


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 