### PR TITLE
challenge - management의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/challenge/management/controller/ManagementController.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/controller/ManagementController.java
@@ -1,13 +1,9 @@
 package daehee.challengehub.challenge.management.controller;
 
-import daehee.challengehub.challenge.management.model.ChallengeDto;
-import daehee.challengehub.challenge.management.model.ChallengeImageDto;
-import daehee.challengehub.challenge.management.model.ChallengeTagDto;
+import daehee.challengehub.challenge.management.model.*;
 import daehee.challengehub.challenge.management.service.ManagementService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/challenges")
@@ -20,52 +16,52 @@ public class ManagementController {
     }
 
     @PostMapping
-    public Map<String, Object> createChallenge(@RequestBody ChallengeDto challengeData) {
+    public CreateChallengeResponseDto createChallenge(@RequestBody ChallengeDto challengeData) {
         return managementService.createChallenge(challengeData);
     }
 
     @GetMapping
-    public Map<String, Object> getAllChallenges() {
+    public GetAllChallengesResponseDto getAllChallenges() {
         return managementService.getAllChallenges();
     }
 
     @GetMapping("/{id}")
-    public Map<String, Object> getChallengeById(@PathVariable Long id) {
+    public GetChallengeResponseDto getChallengeById(@PathVariable Long id) {
         return managementService.getChallengeById(id);
     }
 
     @PutMapping("/{id}")
-    public Map<String, Object> updateChallenge(@PathVariable Long id, @RequestBody ChallengeDto challengeData) {
+    public UpdateChallengeResponseDto updateChallenge(@PathVariable Long id, @RequestBody ChallengeDto challengeData) {
         return managementService.updateChallenge(id, challengeData);
     }
 
     @DeleteMapping("/{id}")
-    public Map<String, String> deleteChallenge(@PathVariable Long id) {
+    public DeleteChallengeResponseDto deleteChallenge(@PathVariable Long id) {
         return managementService.deleteChallenge(id);
     }
 
     @PostMapping("/{id}/participation")
-    public Map<String, String> participateInChallenge(@PathVariable Long id) {
+    public ParticipateInChallengeResponseDto participateInChallenge(@PathVariable Long id) {
         return managementService.participateInChallenge(id);
     }
 
     @PostMapping("/{id}/tags")
-    public Map<String, Object> addTagToChallenge(@PathVariable Long id, @RequestBody ChallengeTagDto tagData) {
+    public AddTagResponseDto addTagToChallenge(@PathVariable Long id, @RequestBody ChallengeTagDto tagData) {
         return managementService.addTagToChallenge(id, tagData);
     }
 
     @DeleteMapping("/{id}/tags/{tagId}")
-    public Map<String, String> removeTagFromChallenge(@PathVariable Long id, @PathVariable Long tagId) {
+    public RemoveTagResponseDto removeTagFromChallenge(@PathVariable Long id, @PathVariable Long tagId) {
         return managementService.removeTagFromChallenge(id, tagId);
     }
 
     @PostMapping("/{id}/images")
-    public Map<String, Object> uploadImageToChallenge(@PathVariable Long id, @RequestBody ChallengeImageDto imageData) {
+    public UploadImageResponseDto uploadImageToChallenge(@PathVariable Long id, @RequestBody ChallengeImageDto imageData) {
         return managementService.uploadImageToChallenge(id, imageData);
     }
 
     @DeleteMapping("/{id}/images/{imageId}")
-    public Map<String, String> removeImageFromChallenge(@PathVariable Long id, @PathVariable Long imageId) {
+    public RemoveImageResponseDto removeImageFromChallenge(@PathVariable Long id, @PathVariable Long imageId) {
         return managementService.removeImageFromChallenge(id, imageId);
     }
 }

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/AddTagResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/AddTagResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class AddTagResponseDto {
+    private final String message;
+    private final ChallengeTagDto tag;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/CreateChallengeResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/CreateChallengeResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class CreateChallengeResponseDto {
+    private final String message;
+    private final ChallengeDto challenge;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/DeleteChallengeResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/DeleteChallengeResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class DeleteChallengeResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/GetAllChallengesResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/GetAllChallengesResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GetAllChallengesResponseDto {
+    private final List<ChallengeDto> challenges;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/GetChallengeResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/GetChallengeResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class GetChallengeResponseDto {
+    private final ChallengeDto challenge;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/ParticipateInChallengeResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/ParticipateInChallengeResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class ParticipateInChallengeResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/RemoveImageResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/RemoveImageResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class RemoveImageResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/RemoveTagResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/RemoveTagResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class RemoveTagResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/UpdateChallengeResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/UpdateChallengeResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class UpdateChallengeResponseDto {
+    private final String message;
+    private final ChallengeDto updatedChallenge;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/model/UploadImageResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/model/UploadImageResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.management.model;
+
+import lombok.Data;
+
+@Data
+public class UploadImageResponseDto {
+    private final String message;
+    private final ChallengeImageDto image;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/management/service/ManagementService.java
+++ b/api/src/main/java/daehee/challengehub/challenge/management/service/ManagementService.java
@@ -1,15 +1,11 @@
 package daehee.challengehub.challenge.management.service;
 
-import daehee.challengehub.challenge.management.model.ChallengeDto;
-import daehee.challengehub.challenge.management.model.ChallengeImageDto;
-import daehee.challengehub.challenge.management.model.ChallengeTagDto;
+import daehee.challengehub.challenge.management.model.*;
 import daehee.challengehub.challenge.management.repository.ManagementRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class ManagementService {
@@ -21,89 +17,53 @@ public class ManagementService {
         this.managementRepository = managementRepository;
     }
 
-    public Map<String, Object> createChallenge(ChallengeDto challengeData) {
+    public CreateChallengeResponseDto createChallenge(ChallengeDto challengeData) {
         managementRepository.createChallenge(challengeData);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 생성 성공");
-        response.put("createdChallenge", challengeData);
-        return response;
+        return new CreateChallengeResponseDto("챌린지 생성 성공", challengeData);
     }
 
-    public Map<String, Object> getAllChallenges() {
+    public GetAllChallengesResponseDto getAllChallenges() {
         List<ChallengeDto> challenges = managementRepository.getAllChallenges();
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 목록 조회 성공");
-        response.put("challenges", challenges);
-        return response;
+        return new GetAllChallengesResponseDto(challenges);
     }
 
-    public Map<String, Object> getChallengeById(Long challengeId) {
+    public GetChallengeResponseDto getChallengeById(Long challengeId) {
         ChallengeDto challenge = managementRepository.getChallengeById(challengeId);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 상세 조회 성공");
-        response.put("challenge", challenge);
-        return response;
+        return new GetChallengeResponseDto(challenge);
     }
 
-    public Map<String, Object> updateChallenge(Long challengeId, ChallengeDto challengeData) {
+    public UpdateChallengeResponseDto updateChallenge(Long challengeId, ChallengeDto challengeData) {
         managementRepository.updateChallenge(challengeId, challengeData);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 수정 성공");
-        response.put("updatedChallenge", challengeData);
-        return response;
+        return new UpdateChallengeResponseDto("챌린지 수정 성공", challengeData);
     }
 
-    public Map<String, String> deleteChallenge(Long challengeId) {
+    public DeleteChallengeResponseDto deleteChallenge(Long challengeId) {
         managementRepository.deleteChallenge(challengeId);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "챌린지 삭제 성공: 챌린지 ID " + challengeId);
-        return response;
+        return new DeleteChallengeResponseDto("챌린지 삭제 성공: 챌린지 ID " + challengeId);
     }
 
-    public Map<String, Object> addTagToChallenge(Long challengeId, ChallengeTagDto tagData) {
+    public AddTagResponseDto addTagToChallenge(Long challengeId, ChallengeTagDto tagData) {
         managementRepository.addTagToChallenge(challengeId, tagData);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "태그 추가 성공");
-        response.put("tagDetails", tagData);
-        return response;
+        return new AddTagResponseDto("태그 추가 성공", tagData);
     }
 
-    public Map<String, String> removeTagFromChallenge(Long challengeId, Long tagId) {
+    public RemoveTagResponseDto removeTagFromChallenge(Long challengeId, Long tagId) {
         managementRepository.removeTagFromChallenge(challengeId, tagId);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "태그 삭제 성공: 태그 ID " + tagId + " 챌린지 ID " + challengeId);
-        return response;
+        return new RemoveTagResponseDto("태그 삭제 성공: 태그 ID " + tagId + " 챌린지 ID " + challengeId);
     }
 
-    public Map<String, Object> uploadImageToChallenge(Long challengeId, ChallengeImageDto imageData) {
+    public UploadImageResponseDto uploadImageToChallenge(Long challengeId, ChallengeImageDto imageData) {
         managementRepository.uploadImageToChallenge(challengeId, imageData);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "이미지 업로드 성공");
-        response.put("imageDetails", imageData);
-        return response;
+        return new UploadImageResponseDto("이미지 업로드 성공", imageData);
     }
 
-    public Map<String, String> removeImageFromChallenge(Long challengeId, Long imageId) {
+    public RemoveImageResponseDto removeImageFromChallenge(Long challengeId, Long imageId) {
         managementRepository.removeImageFromChallenge(challengeId, imageId);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "이미지 삭제 성공: 이미지 ID " + imageId + " 챌린지 ID " + challengeId);
-        return response;
+        return new RemoveImageResponseDto("이미지 삭제 성공: 이미지 ID " + imageId + " 챌린지 ID " + challengeId);
     }
 
-    public Map<String, String> participateInChallenge(Long challengeId) {
+    public ParticipateInChallengeResponseDto participateInChallenge(Long challengeId) {
         // TODO: 참가자 데이터 처리 로직 구현 필요
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "챌린지 참여 성공: 챌린지 ID " + challengeId);
-        return response;
+        return new ParticipateInChallengeResponseDto("챌린지 참여 성공: 챌린지 ID " + challengeId);
     }
 }
-

--- a/api/src/test/java/challenge/service/ManagementServiceTest.java
+++ b/api/src/test/java/challenge/service/ManagementServiceTest.java
@@ -1,26 +1,20 @@
 package challenge.service;
 
-import daehee.challengehub.challenge.management.model.ChallengeDto;
-import daehee.challengehub.challenge.management.model.ChallengeImageDto;
-import daehee.challengehub.challenge.management.model.ChallengeTagDto;
+import daehee.challengehub.challenge.management.model.*;
 import daehee.challengehub.challenge.management.repository.ManagementRepository;
 import daehee.challengehub.challenge.management.service.ManagementService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Map;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ManagementServiceTest {
@@ -49,11 +43,11 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).createChallenge(any(ChallengeDto.class));
 
         // When
-        Map<String, Object> response = managementService.createChallenge(challengeData);
+        CreateChallengeResponseDto response = managementService.createChallenge(challengeData);
 
         // Then
-        assertEquals("챌린지 생성 성공", response.get("message"));
-        assertEquals(challengeData, response.get("createdChallenge"));
+        assertEquals("챌린지 생성 성공", response.getMessage());
+        assertEquals(challengeData, response.getChallenge());
         verify(managementRepository).createChallenge(any(ChallengeDto.class));
     }
 
@@ -89,11 +83,11 @@ public class ManagementServiceTest {
         when(managementRepository.getAllChallenges()).thenReturn(mockChallenges);
 
         // When
-        Map<String, Object> response = managementService.getAllChallenges();
+        GetAllChallengesResponseDto response = managementService.getAllChallenges();
 
         // Then
-        assertEquals("챌린지 목록 조회 성공", response.get("message"));
-        assertEquals(mockChallenges, response.get("challenges"));
+//        assertEquals("챌린지 목록 조회 성공", response.getMessage());
+        assertEquals(mockChallenges, response.getChallenges());
     }
 
     @Test
@@ -115,11 +109,11 @@ public class ManagementServiceTest {
         when(managementRepository.getChallengeById(challengeId)).thenReturn(mockChallenge);
 
         // When
-        Map<String, Object> response = managementService.getChallengeById(challengeId);
+        GetChallengeResponseDto response = managementService.getChallengeById(challengeId);
 
         // Then
-        assertEquals("챌린지 상세 조회 성공", response.get("message"));
-        assertEquals(mockChallenge, response.get("challenge"));
+//        assertEquals("챌린지 상세 조회 성공", response.getMessage());
+        assertEquals(mockChallenge, response.getChallenge());
     }
 
     @Test
@@ -141,11 +135,11 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).updateChallenge(eq(challengeId), any(ChallengeDto.class));
 
         // When
-        Map<String, Object> response = managementService.updateChallenge(challengeId, challengeData);
+        UpdateChallengeResponseDto response = managementService.updateChallenge(challengeId, challengeData);
 
         // Then
-        assertEquals("챌린지 수정 성공", response.get("message"));
-        assertEquals(challengeData, response.get("updatedChallenge"));
+        assertEquals("챌린지 수정 성공", response.getMessage());
+        assertEquals(challengeData, response.getUpdatedChallenge());
         verify(managementRepository).updateChallenge(eq(challengeId), any(ChallengeDto.class));
     }
 
@@ -156,10 +150,10 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).deleteChallenge(challengeId);
 
         // When
-        Map<String, String> response = managementService.deleteChallenge(challengeId);
+        DeleteChallengeResponseDto response = managementService.deleteChallenge(challengeId);
 
         // Then
-        assertEquals("챌린지 삭제 성공: 챌린지 ID " + challengeId, response.get("message"));
+        assertEquals("챌린지 삭제 성공: 챌린지 ID " + challengeId, response.getMessage());
         verify(managementRepository).deleteChallenge(challengeId);
     }
 
@@ -174,11 +168,11 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).addTagToChallenge(eq(challengeId), any(ChallengeTagDto.class));
 
         // When
-        Map<String, Object> response = managementService.addTagToChallenge(challengeId, tagData);
+        AddTagResponseDto response = managementService.addTagToChallenge(challengeId, tagData);
 
         // Then
-        assertEquals("태그 추가 성공", response.get("message"));
-        assertEquals(tagData, response.get("tagDetails"));
+        assertEquals("태그 추가 성공", response.getMessage());
+        assertEquals(tagData, response.getTag());
         verify(managementRepository).addTagToChallenge(eq(challengeId), any(ChallengeTagDto.class));
     }
 
@@ -190,10 +184,10 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).removeTagFromChallenge(challengeId, tagId);
 
         // When
-        Map<String, String> response = managementService.removeTagFromChallenge(challengeId, tagId);
+        RemoveTagResponseDto response = managementService.removeTagFromChallenge(challengeId, tagId);
 
         // Then
-        assertEquals("태그 삭제 성공: 태그 ID " + tagId + " 챌린지 ID " + challengeId, response.get("message"));
+        assertEquals("태그 삭제 성공: 태그 ID " + tagId + " 챌린지 ID " + challengeId, response.getMessage());
         verify(managementRepository).removeTagFromChallenge(challengeId, tagId);
     }
 
@@ -208,11 +202,11 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).uploadImageToChallenge(eq(challengeId), any(ChallengeImageDto.class));
 
         // When
-        Map<String, Object> response = managementService.uploadImageToChallenge(challengeId, imageData);
+        UploadImageResponseDto response = managementService.uploadImageToChallenge(challengeId, imageData);
 
         // Then
-        assertEquals("이미지 업로드 성공", response.get("message"));
-        assertEquals(imageData, response.get("imageDetails"));
+        assertEquals("이미지 업로드 성공", response.getMessage());
+        assertEquals(imageData, response.getImage());
         verify(managementRepository).uploadImageToChallenge(eq(challengeId), any(ChallengeImageDto.class));
     }
 
@@ -224,10 +218,10 @@ public class ManagementServiceTest {
         doNothing().when(managementRepository).removeImageFromChallenge(challengeId, imageId);
 
         // When
-        Map<String, String> response = managementService.removeImageFromChallenge(challengeId, imageId);
+        RemoveImageResponseDto response = managementService.removeImageFromChallenge(challengeId, imageId);
 
         // Then
-        assertEquals("이미지 삭제 성공: 이미지 ID " + imageId + " 챌린지 ID " + challengeId, response.get("message"));
+        assertEquals("이미지 삭제 성공: 이미지 ID " + imageId + " 챌린지 ID " + challengeId, response.getMessage());
         verify(managementRepository).removeImageFromChallenge(challengeId, imageId);
     }
 }


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 