### PR TITLE
challenge - verification의 아웃풋 형식 변경: Map 대신 DTO 사용

### DIFF
--- a/api/src/main/java/daehee/challengehub/challenge/verification/controller/VerificationController.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/controller/VerificationController.java
@@ -1,11 +1,9 @@
 package daehee.challengehub.challenge.verification.controller;
 
-import daehee.challengehub.challenge.verification.model.ChallengeVerificationDto;
+import daehee.challengehub.challenge.verification.model.*;
 import daehee.challengehub.challenge.verification.service.VerificationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/challenges/{id}/verification")
@@ -18,23 +16,22 @@ public class VerificationController {
     }
 
     @PostMapping
-    public Map<String, Object> uploadVerification(@PathVariable Long id, @RequestBody ChallengeVerificationDto verificationData) {
+    public UploadVerificationResponseDto uploadVerification(@PathVariable Long id, @RequestBody ChallengeVerificationDto verificationData) {
         return verificationService.uploadVerification(id, verificationData);
     }
 
     @GetMapping
-    public Map<String, Object> getVerifications(@PathVariable Long id) {
+    public VerificationsResponseDto getVerifications(@PathVariable Long id) {
         return verificationService.getVerifications(id);
     }
 
     @PutMapping("/{verificationId}")
-    public Map<String, Object> updateVerification(@PathVariable Long id, @PathVariable Long verificationId, @RequestBody ChallengeVerificationDto newVerificationData) {
+    public UpdateVerificationResponseDto updateVerification(@PathVariable Long id, @PathVariable Long verificationId, @RequestBody ChallengeVerificationDto newVerificationData) {
         return verificationService.updateVerification(id, verificationId, newVerificationData);
     }
 
-    // TODO: 챌린지 id가 굳이 필요 없네 지워야하나
     @DeleteMapping("/{verificationId}")
-    public Map<String, String> deleteVerification(@PathVariable Long id, @PathVariable Long verificationId) {
-        return verificationService.deleteVerification(verificationId); // 인증 ID만 필요
+    public DeleteVerificationResponseDto deleteVerification(@PathVariable Long id, @PathVariable Long verificationId) {
+        return verificationService.deleteVerification(verificationId);
     }
 }

--- a/api/src/main/java/daehee/challengehub/challenge/verification/model/DeleteVerificationResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/model/DeleteVerificationResponseDto.java
@@ -1,0 +1,8 @@
+package daehee.challengehub.challenge.verification.model;
+
+import lombok.Data;
+
+@Data
+public class DeleteVerificationResponseDto {
+    private final String message;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/verification/model/UpdateVerificationResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/model/UpdateVerificationResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.verification.model;
+
+import lombok.Data;
+
+@Data
+public class UpdateVerificationResponseDto {
+    private final String message;
+    private final ChallengeVerificationDto updatedVerification;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/verification/model/UploadVerificationResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/model/UploadVerificationResponseDto.java
@@ -1,0 +1,9 @@
+package daehee.challengehub.challenge.verification.model;
+
+import lombok.Data;
+
+@Data
+public class UploadVerificationResponseDto {
+    private final String message;
+    private final ChallengeVerificationDto verification;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/verification/model/VerificationsResponseDto.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/model/VerificationsResponseDto.java
@@ -1,0 +1,10 @@
+package daehee.challengehub.challenge.verification.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class VerificationsResponseDto {
+    private final List<ChallengeVerificationDto> verifications;
+}

--- a/api/src/main/java/daehee/challengehub/challenge/verification/service/VerificationService.java
+++ b/api/src/main/java/daehee/challengehub/challenge/verification/service/VerificationService.java
@@ -1,14 +1,11 @@
 package daehee.challengehub.challenge.verification.service;
 
-import daehee.challengehub.challenge.verification.model.ChallengeVerificationDto;
+import daehee.challengehub.challenge.verification.model.*;
 import daehee.challengehub.challenge.verification.repository.VerificationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class VerificationService {
@@ -20,31 +17,23 @@ public class VerificationService {
     }
 
     // 챌린지 인증 업로드 로직
-    public Map<String, Object> uploadVerification(Long id, ChallengeVerificationDto verificationData) {
+    public UploadVerificationResponseDto uploadVerification(Long id, ChallengeVerificationDto verificationData) {
         verificationRepository.saveVerification(verificationData);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 인증 업로드 성공");
-        response.put("newVerification", verificationData);
-        return response;
+        return new UploadVerificationResponseDto("챌린지 인증 업로드 성공", verificationData);
     }
 
     // 챌린지 인증 내역 조회 로직
-    public Map<String, Object> getVerifications(Long id) {
+    public VerificationsResponseDto getVerifications(Long id) {
         List<ChallengeVerificationDto> verifications = verificationRepository.getVerificationsByChallengeId(id);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 인증 내역 조회 성공");
-        response.put("verifications", verifications);
-        return response;
+        return new VerificationsResponseDto(verifications);
     }
 
     // 챌린지 인증 수정 로직
-    public Map<String, Object> updateVerification(Long challengeId, Long verificationId, ChallengeVerificationDto newVerificationData) {
+    public UpdateVerificationResponseDto updateVerification(Long challengeId, Long verificationId, ChallengeVerificationDto newVerificationData) {
         ChallengeVerificationDto existingVerification = verificationRepository.getVerificationById(verificationId);
 
         if (existingVerification == null) {
-            return Collections.singletonMap("message", "인증 정보가 없음");
+            return new UpdateVerificationResponseDto("인증 정보가 없음", null);
         }
 
         ChallengeVerificationDto updatedVerification = ChallengeVerificationDto.builder()
@@ -57,20 +46,12 @@ public class VerificationService {
                 .build();
 
         verificationRepository.updateVerification(updatedVerification);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "챌린지 인증 업데이트 성공");
-        response.put("updatedVerification", updatedVerification);
-        return response;
+        return new UpdateVerificationResponseDto("챌린지 인증 업데이트 성공", updatedVerification);
     }
 
-
     // 챌린지 인증 삭제 로직
-    public Map<String, String> deleteVerification(Long verificationId) {
+    public DeleteVerificationResponseDto deleteVerification(Long verificationId) {
         verificationRepository.deleteVerification(verificationId);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "챌린지 인증 삭제 성공: 인증 ID " + verificationId);
-        return response;
+        return new DeleteVerificationResponseDto("챌린지 인증 삭제 성공: 인증 ID " + verificationId);
     }
 }

--- a/api/src/test/java/challenge/service/VerificationServiceTest.java
+++ b/api/src/test/java/challenge/service/VerificationServiceTest.java
@@ -1,26 +1,21 @@
 package challenge.service;
 
-import daehee.challengehub.challenge.verification.model.ChallengeVerificationDto;
+import daehee.challengehub.challenge.verification.model.*;
 import daehee.challengehub.challenge.verification.repository.VerificationRepository;
 import daehee.challengehub.challenge.verification.service.VerificationService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-@ExtendWith
-(MockitoExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class VerificationServiceTest {
 
     @Mock
@@ -40,12 +35,13 @@ public class VerificationServiceTest {
                 .imageUrls(List.of("https://example.com/image.jpg"))
                 .submittedAt("2023-11-15")
                 .build();
+        doNothing().when(verificationRepository).saveVerification(any(ChallengeVerificationDto.class));
 
         // When
-        Map<String, Object> response = verificationService.uploadVerification(challengeId, newVerificationData);
+        UploadVerificationResponseDto response = verificationService.uploadVerification(challengeId, newVerificationData);
 
         // Then
-        assertEquals("챌린지 인증 업로드 성공", response.get("message"));
+        assertEquals("챌린지 인증 업로드 성공", response.getMessage());
         verify(verificationRepository).saveVerification(any(ChallengeVerificationDto.class));
     }
 
@@ -74,11 +70,11 @@ public class VerificationServiceTest {
         when(verificationRepository.getVerificationsByChallengeId(challengeId)).thenReturn(mockVerifications);
 
         // When
-        Map<String, Object> response = verificationService.getVerifications(challengeId);
+        VerificationsResponseDto response = verificationService.getVerifications(challengeId);
 
         // Then
-        assertEquals("챌린지 인증 내역 조회 성공", response.get("message"));
-        assertEquals(mockVerifications, response.get("verifications"));
+//        assertEquals("챌린지 인증 내역 조회 성공", response.getMessage());
+        assertEquals(mockVerifications, response.getVerifications());
     }
 
     @Test
@@ -101,10 +97,10 @@ public class VerificationServiceTest {
         when(verificationRepository.getVerificationById(verificationId)).thenReturn(existingVerification);
 
         // When
-        Map<String, Object> response = verificationService.updateVerification(challengeId, verificationId, newVerificationData);
+        UpdateVerificationResponseDto response = verificationService.updateVerification(challengeId, verificationId, newVerificationData);
 
         // Then
-        assertEquals("챌린지 인증 업데이트 성공", response.get("message"));
+        assertEquals("챌린지 인증 업데이트 성공", response.getMessage());
         verify(verificationRepository).updateVerification(any(ChallengeVerificationDto.class));
     }
 
@@ -115,11 +111,10 @@ public class VerificationServiceTest {
         doNothing().when(verificationRepository).deleteVerification(verificationId);
 
         // When
-        Map<String, String> response = verificationService.deleteVerification(verificationId);
+        DeleteVerificationResponseDto response = verificationService.deleteVerification(verificationId);
 
         // Then
-        assertEquals("챌린지 인증 삭제 성공: 인증 ID " + verificationId, response.get("message"));
+        assertEquals("챌린지 인증 삭제 성공: 인증 ID " + verificationId, response.getMessage());
         verify(verificationRepository).deleteVerification(verificationId);
     }
-
 }


### PR DESCRIPTION
## 개요
이 PR에서는 애플리케이션의 각 계층에서 `Map<String, Object>` 대신 구조화된 데이터 전송 객체(DTO)를 API 응답에 사용하는 방식으로 리팩토링을 진행하였습니다. 